### PR TITLE
cslice limit option

### DIFF
--- a/src/cslice.rs
+++ b/src/cslice.rs
@@ -14,20 +14,35 @@ fn main() -> io::Result<()> {
                     .arg(Arg::with_name("skip")
                         .help("Rows to skip")
                         .index(2))
+                    .arg(Arg::with_name("limit")
+                        .short("l")
+                        .long("limit")
+                        .takes_value(true)
+                        .value_name("limit")
+                        .default_value("")
+                        .help("Limit output"))
                     .get_matches();
 
 
     let col_arg = cslice.value_of("column").unwrap_or("0");
     let skip_arg = cslice.value_of("skip").unwrap_or("0");
+    let limit_arg = cslice.value_of("limit").unwrap();
 
     let mut buffer = String::new();
     let stdin = io::stdin();
     let mut handle = stdin.lock();
     handle.read_to_string(&mut buffer)?;
 
+    let mut i:i128 = 0;
+
     for l in buffer.lines().skip(skip_arg.parse::<usize>().unwrap()) {
         if !l.is_empty() {
             println!("{}", l.split_whitespace().nth(col_arg.parse::<usize>().unwrap()).unwrap());
+        }
+
+        if limit_arg != "" {
+            i+=1;
+            if limit_arg.parse::<i128>().unwrap() == i { break; }
         }
     }
 


### PR DESCRIPTION
```
➜  echo "meow\nyo\nmeow" | cargo run --bin cslice 0 --limit 1
meow
```